### PR TITLE
Defaults for CalendarDay `width` and `height` to avoid random crashes

### DIFF
--- a/src/CalendarDay.js
+++ b/src/CalendarDay.js
@@ -70,6 +70,8 @@ class CalendarDay extends Component {
     showDayName: true,
     showDayNumber: true,
     upperCaseDays: true,
+    width: 0, // Default width and height to avoid calcSizes() *sometimes* doing Math.round(undefined) to cause NaN
+    height: 0
   };
 
   constructor(props) {


### PR DESCRIPTION
CalendarDay's `calcSizes` calculates a responsive containerHeight by doing `Math.round(props.height)`. Ditto for the width.

During development, `props.height` would sometimes be `undefined`, causing it to do `Math.random(undefined)` which yields `NaN`. That in turn led to the following, causing an app crash on Android:

```
Invariant Violation: [847,"RCTView",81,{"justifyContent":"center","alignItems":"center","alignSelf":"center","width":0,"height":"<<NaN>>","borderRadius":0,"backgroundColor":0}] is not usable as a native method argument
```

That's when using JSC. Using Hermes you don't get any useful error at all, it just crashes.